### PR TITLE
README.md: minor fixes to cron section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ To update the wallpaper only once (Instead of checking every 3 hours), Run:
     $ bingwallpaper -1
 
 ## Setting Up Cron
-Do not use sudo, as it will set up the cron for root, which will not change the wallpaper for the current user. To edit crontab for current user do:
+To setup regular checks for new wallapers, edit crontab for the current user, using:
 
     $ crontab -u $USER -e
 
-We would only need to run it once, because cron will be re-running this, so:
+, and add this line:
 
-    $ * */6 * * * bingwallpaper true >/dev/null 2>&1
+    0 */6 * * * bingwallpaper -1 > /dev/null 2>&1
 
-This will run this every 6 hours. You can use [this link](http://www.crontab-generator.org/) for reference.
+This will run every 6 hours. You can use [this link](http://www.crontab-generator.org/) for reference.
 
 *Note: If you installed this package from apt, then disable the startup script setup by default. Go to startup applications and remove 'bingwallpaper'*
 


### PR DESCRIPTION
**Changes** 

- Change minute in crontab from `*` to `0`, otherwise we run the cron _every_ minute.
- Remove advice against using `sudo`. `sudo` may be required to use the `-u` flag -- this is the case on my Fedora 25 machine. The use of `-u $USER` should edit the correct crontab, whether `sudo` is used or not.
- Use argument `-1` instead of `true` to cause `bingwallpaper` to quit after running -- in my testing, this seemed to be the right usage.