### PR TITLE
Spider should not follow redirects

### DIFF
--- a/bingwallpaper
+++ b/bingwallpaper
@@ -72,7 +72,7 @@ do
   copyright=$(echo $apiResp | grep -oP "copyright\":\"[^\"]*" | cut -d "\"" -f 3)
 
   # Checking if reqImgURL exists.
-  if ! wget --quiet --spider $reqImgURL; then
+  if ! wget --quiet --spider --max-redirect 0 $reqImgURL; then
     reqImgURL=$defImgURL
   fi
 


### PR DESCRIPTION
There are occasions where the requested resolution does not exist on the server.

e.g. http://www.bing.com/az/hprichbg/rb/MoriBuilding_EN-US5143587469_1920x1200.jpg

In that case a redirect to the default image is returned: http://www.bing.com/s/hpb/NorthMale_EN-US8782628354_1920x1200.jpg
This also results in a black background (Ubuntu 16.04 with Unity)

If the check won't follow redirects, the original resolution from the API response will be downloaded and the wallpaper is successfully applied