### PR TITLE
add support for i3-wm

### DIFF
--- a/bingwallpaper
+++ b/bingwallpaper
@@ -101,6 +101,9 @@ do
     do
       xfconf-query --channel xfce4-desktop --property $x --set $path$imgName
     done
+  elif [ "$XDG_CURRENT_DESKTOP" = "i3" ]
+  then
+    feh --bg-scale $path$imgName
   elif [ "$XDG_CURRENT_DESKTOP" = "MATE" ]
   then
     gsettings set org.mate.background picture-filename $path$imgName


### PR DESCRIPTION
For i3-wm users, add `exec --no-startup-id path/to/bingwallpaper -1` to `~/.config/i3/config`.